### PR TITLE
To ensure that @@platform doesn't remain uninitailized in set_platform()

### DIFF
--- a/lib/platform.rb
+++ b/lib/platform.rb
@@ -322,9 +322,9 @@ private
 				@@platform = "centos" if line.include?("CentOS")
 			elsif File.exist?('/mach_kernel')
 				@@platform = "mac"
-			else
-				@@platform = nil
 			end
+			#To ensure that @@platform is either set or nil:
+			@@platform ||= nil
 			raise "unsupported platform #{@@platform}" unless PLATFORMS.include?(@@platform)
 		end
 


### PR DESCRIPTION
In case system contains `/etc/issue`, but isn't any of {debian, fedora,fedora,centos}, `@@platform` remained **uninitialized** in that condition block. Now because it found `/etc/issue`, it doesn't get in any other condition block and `@@platform` isn't set to `nil` as intended for unsupported platforms.

Because of this, one couldn't perform any rake task or initialize server: 
**Error log:**

```
$: platform git:(fix/set_platform)> rake db:seed
rake aborted!
uninitialized class variable @@platform in Platform
/home/ankur/amahi/platform/lib/platform.rb:329:in `set_platform'
/home/ankur/amahi/platform/lib/platform.rb:383:in `<class:Platform>'
/home/ankur/amahi/platform/lib/platform.rb:19:in `<top (required)>'
```

The commit below ensures that `@@platform` is set to nil in case it isn't initialized in any condition. 

Alternatively, we can set `@@platform = line.chomp` incase the type of system obtained from `/etc/issue` isn't one of those mentioned above. It will make the raised exception clear, mentioning specifically that _obtained_ system isn't supported.
