### PR TITLE
Fixed pending tests of completed features

### DIFF
--- a/spec/features/users_tab_spec.rb
+++ b/spec/features/users_tab_spec.rb
@@ -82,11 +82,11 @@ feature "Users tab" do
 		page.has_text?("Username")
 		page.has_text?("Full Name")
 		find("#whole_user_#{user.id}").find("tr").click_link user.login
-		checkbox = "#checkbox_user_admin_#{user.id}"
-		pending "FIXME: issues with JS?"
+		checkbox = "checkbox_user_admin_#{user.id}"
 		page.should have_checked_field(checkbox)
-		page.uncheck(checkbox);
-		expect(page.find_by_id(checkbox)[:checked]).to neq 'checked'
+		page.uncheck(checkbox)
+		wait_for_ajax
+		expect(user.reload.admin?).to eq false
 		page.should have_unchecked_field(checkbox)
 	end
 	scenario "should allow an admin user to promote a regular user to admin", :js => true do
@@ -102,10 +102,12 @@ feature "Users tab" do
 		page.has_text?("Username")
 		page.has_text?("Full Name")
 		find("#whole_user_#{user.id}").find("tr").click_link user.login
-		checkbox = "#checkbox_user_admin_#{user.id}"
-		pending "FIXME: issues with JS?"
+		checkbox = "checkbox_user_admin_#{user.id}"
+		expect(user.admin?).to eq false
 		page.should_not have_checked_field(checkbox)
-		page.check(checkbox);
+		page.check(checkbox)
+		wait_for_ajax
+		expect(user.reload.admin?).to eq true
 		page.should have_checked_field(checkbox)
 	end
 	scenario "should allow an admin user to change his full name" do

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,0 +1,15 @@
+module WaitForAjax
+  def wait_for_ajax
+    Timeout.timeout(Capybara.default_wait_time) do
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
+  end
+end
+
+RSpec.configure do |config|
+  config.include WaitForAjax, type: :feature
+end


### PR DESCRIPTION
Some tests were pending because they were failing although the
feature itself was working correctly. I've made some improvements
to these tests and made them work. The reason for failing was
mainly due to not waiting for ajax requests to complete and there
was a mistake in specifying the checkbox variable.
