### PR TITLE
Validation constraint added for workgroup

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -27,6 +27,12 @@ class Setting < ActiveRecord::Base
 	scope :network, by_kind(NETWORK)
 	scope :shares,  by_kind(SHARES)
 
+	validates :value,
+	          :length => { :maximum => 15 },
+	          :format => { :with => /^[a-zA-Z][a-zA-Z0-9]{0,14}$/ },
+	          :if => Proc.new { |x| x.kind.eql?(Setting::GENERAL) && x.name.eql?('workgroup') },
+	          :on => :update
+
 	class << self
 
 		def value_by_name(name)

--- a/plugins/020-shares/app/controllers/shares_controller.rb
+++ b/plugins/020-shares/app/controllers/shares_controller.rb
@@ -99,11 +99,11 @@ class SharesController < ApplicationController
 
 	def update_workgroup
 		sleep 2 if development?
-		@workgroup = Setting.find(params[:id])
+		@workgroup = Setting.find(params[:id]) if params[:id]
 		if @workgroup && @workgroup.name.eql?("workgroup")
-			 @workgroup.update_attributes(params[:share])
+			@saved = @workgroup.update_attributes(params[:share])
 		end
-		render :json => { :status => @workgroup ? :ok : :not_acceptable }
+		render :json => { :status => @saved ? :ok : :not_acceptable }
 	end
 
 	def update_extras


### PR DESCRIPTION
Added validation constraint on `value` for **Workgroup**. In follow up of [Bug #1079](https://bugs.amahi.org/issues/1079).
Workgroup must have:
- maximum length of 15
- should not contain any special characters

For this, I am validating the `value` for both these conditions by - `if` that record is of `kind` 'general' and has `name = workgroup`. On updation of such record, this validation is triggered.
