### PR TITLE
update 'partitions' sub-tab to show partition structor more clearly using pie chart

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'unicorn'
 
 gem 'rb-readline', require: false
 
+gem 'chartkick'
 group :development do
 	gem 'quiet_assets'
 	gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     capybara-screenshot (0.3.17)
       capybara (>= 1.0, < 3)
       launchy
+    chartkick (1.2.2)
     cliver (0.3.2)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
@@ -197,6 +198,7 @@ DEPENDENCIES
   bcrypt
   capybara
   capybara-screenshot
+  chartkick
   coffee-rails
   factory_girl_rails
   jbuilder

--- a/plugins/030-disks/app/assets/javascripts/disks.js
+++ b/plugins/030-disks/app/assets/javascripts/disks.js
@@ -1,0 +1,7 @@
+$(document).ready(function() {
+
+	$("#disk-table-head").click(function() {
+
+		$("#disk-table-body").slideToggle();
+	});
+});

--- a/plugins/030-disks/app/assets/stylesheets/disks.css
+++ b/plugins/030-disks/app/assets/stylesheets/disks.css
@@ -13,4 +13,6 @@
 	display: none;
 }
 
-
+#content {
+	overflow: hidden;
+}

--- a/plugins/030-disks/app/assets/stylesheets/disks.css
+++ b/plugins/030-disks/app/assets/stylesheets/disks.css
@@ -1,0 +1,7 @@
+
+.center_block {
+	margin-left: auto;
+	margin-right: auto;
+	width: 70%;
+}
+

--- a/plugins/030-disks/app/assets/stylesheets/disks.css
+++ b/plugins/030-disks/app/assets/stylesheets/disks.css
@@ -1,4 +1,3 @@
-
 .center_block {
 	margin-left: auto;
 	margin-right: auto;
@@ -16,3 +15,8 @@
 #content {
 	overflow: hidden;
 }
+
+.td_box {
+	width: 40%;
+}
+

--- a/plugins/030-disks/app/assets/stylesheets/disks.css
+++ b/plugins/030-disks/app/assets/stylesheets/disks.css
@@ -5,3 +5,12 @@
 	width: 70%;
 }
 
+#disk-table-head {
+	cursor: pointer;
+}
+
+#disk-table-body {
+	display: none;
+}
+
+

--- a/plugins/030-disks/app/views/disks/mounts.html.slim
+++ b/plugins/030-disks/app/views/disks/mounts.html.slim
@@ -53,7 +53,7 @@
    		table
 		    - @mounts.each_slice(2) do | first, second |
 				tr
-			        td
+			        td.td_box
 				    	  h3.center_block
 				    		 = first[:mount]
 				    		 | &nbsp;&nbsp;&nbsp;
@@ -69,7 +69,7 @@
 			              slices: [{color: '#A44585'},{color: '#00B5F0'}] \
 			              })
 	            	- if second
-	            		td
+	            		td.td_box
 	            			h3.center_block
 					    		 = second[:mount]
 					    		 | &nbsp;&nbsp;&nbsp;

--- a/plugins/030-disks/app/views/disks/mounts.html.slim
+++ b/plugins/030-disks/app/views/disks/mounts.html.slim
@@ -1,24 +1,96 @@
+= javascript_include_tag "//www.google.com/jsapi", "chartkick"
 .settings-table#disks-table
   table.settings
-    thead
+    thead#disk-table-head
       tr
         th.settings-col1= t 'partition'
         th = t 'total_space'
         th = t 'free_space'
         th = t 'used_space'
         th = t 'mount point'
-    tbody
+    tbody#disk-table-body
       -if @mounts.any?
+      	- total_space = 0
+      	- used_space = 0
+      	- free_space = 0
         - @mounts.each do | mount |
           tr class=cycle("odd", "even")
+          	- total_space += mount[:bytes]
+          	- used_space += mount[:used]
+          	- free_space += mount[:available]
             td.settings-col1 = mount[:filesystem]
             td = number_to_human_size mount[:bytes]
             td = number_to_human_size mount[:available]
             td
               = number_to_human_size mount[:used]
               = " (#{mount[:use_percent]})"
-            td = mount[:mount]
+          	td = mount[:mount]
       -else
         tr
           td colspan="6"
             strong No data returned
+
+  .settings
+   .partitions_summary.center_block
+   		table.center
+   			tr
+   				td
+   					= "Free space:" 
+   				td
+   					= number_to_human_size(free_space)
+   			tr
+   				td
+   					= "Used space:" 
+   				td
+   					= number_to_human_size(used_space)
+   			tr
+   				td
+   					= "Total space:" 
+   				td
+   					= number_to_human_size(total_space)
+
+   -if @mounts.any?
+   		table
+		    - @mounts.each_slice(2) do | first, second |
+				tr
+			        td
+				    	  h3.center_block
+				    		 = first[:mount]
+				    		 | &nbsp;&nbsp;&nbsp;
+				    		 = number_to_human_size first[:bytes] 
+			
+			              = pie_chart({"Free: #{number_to_human_size first[:available]}" => first[:available], \
+			              "Used: #{number_to_human_size first[:used]}" => first[:used]},\
+			              library: {legend: {position: 'top'}, \
+			              is3D: true, \
+			              pieSliceText: 'percentage', \
+			              tooltip: {text: 'percentage' }, \
+			              width: 400, \
+			              slices: [{color: '#A44585'},{color: '#00B5F0'}] \
+			              })
+	            	- if second
+	            		td
+	            			h3.center_block
+					    		 = second[:mount]
+					    		 | &nbsp;&nbsp;&nbsp;
+					    		 = number_to_human_size second[:bytes] 
+
+				            = pie_chart({"Free: #{number_to_human_size second[:available]}" => second[:available], \
+				              "Used: #{number_to_human_size second[:used]}" => second[:used]},\
+				              library: {legend: {position: 'top'}, \
+				              is3D: true, \
+				              pieSliceText: 'percentage', \
+				              tooltip: {text: 'percentage' }, \
+				              width: 400, \
+			              	  slices: [{color: '#A44585'},{color: '#00B5F0'}] \
+
+				              })
+	    		 
+	    			
+	    	
+	    		  	
+   -else
+	    tr
+	      td colspan="6"
+	        strong No data returned
+


### PR DESCRIPTION
Use 3-D pie chart(from chartkick) to display partitions stats in more user friendly manner.
Colors used in slices are influenced  by https://kuler.adobe.com/Amahi-colors-color-theme-2048199/
