### PR TITLE
Fixed bug #1072

### DIFF
--- a/app/assets/themes/default/stylesheets/style.css.scss
+++ b/app/assets/themes/default/stylesheets/style.css.scss
@@ -108,7 +108,10 @@ input[type="password"] {
     outline: thin dotted \9; /* IE6-9 */
   }
 }
-
+.inactive{
+  pointer-events: none;
+  cursor: default;
+}
 .form-inline {
   @include clearfix;
 

--- a/plugins/040-apps/app/assets/javascripts/apps.js.coffee
+++ b/plugins/040-apps/app/assets/javascripts/apps.js.coffee
@@ -5,6 +5,9 @@ Apps =
 		$(document).on "ajax:beforeSend", ".install-app-in-background, .uninstall-app-in-background", ->
 				$(".install-button").hide()
 				_this.toggle_spinner this
+				$('.app').each -> 
+					$(this).find('.install-app-in-background').addClass('inactive')
+
 
 		$(document).on "ajax:success", ".install-app-in-background, .uninstall-app-in-background", (data, results) ->
 				_this.update_progress results["identifier"], results["content"]
@@ -61,10 +64,15 @@ Apps =
 			url: _this.app(finder).data("progressPath")
 			success: (data) ->
 				_this.update_progress_message finder, data["content"]
+				
 				if data["app_content"]
 					_this.update_installed_app finder, data["app_content"]
+					$('.app').each -> 
+						$(this).find('.install-app-in-background').removeClass('inactive')
+
 				else if data["uninstalled"]
 					_this.update_uninstalled_app finder
+				
 				else
 					setTimeout (-> Apps.trace_progress(finder)), 2000
 


### PR DESCRIPTION
All other install buttons is deactivated when a particular app is installed.After 100% completion of the installation, all the other buttons gets activated.This needs to checked as I don't have Amahi server installed on my laptop(so there are no apps locally), so after 100% installation the buttons gets activated or not I am not sure.I have placed the JavaScript in 'trace progress method ' in the if part, after much debugging of what happens when the install button is clicked.The control flows through this ''trace progress' method to the install_progress action of apps controller where it is checks the status of installation.If it is not 100% then again on success the ''trace progress'' method is called recursively.On 100% completion the if part is executed so I placed the js for activation of buttons here.
