### PR TITLE
Fix themes full_url

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -313,7 +313,13 @@ class App < ActiveRecord::Base
 	end
 
 	def full_url
-		webapp ? webapp.full_url : "http://#{app_url}.#{Setting.value_by_name('domain')}"
+		if webapp
+			webapp.full_url
+		elsif theme?
+			"/tab/settings/themes"
+		else
+			"http://#{app_url}.#{Setting.value_by_name('domain')}"
+		end
 	end
 
 	def testing?


### PR DESCRIPTION
With this fix,"Manage Themes" link, which appears after installing a theme, will have a valid path to manage(change) themes
