### PR TITLE
Allowing plugins to be added as a submenu of existing tab

### DIFF
--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -17,13 +17,22 @@
 module TabsHelper
 
 	def tab_class(tab)
-		klass = params[:controller] == tab.id ? 'active' : ''
+		if params[:controller] == tab.id
+			klass = 'active'
+		else
+			tabs = Tab.find(tab.id)
+			if tabs.empty?
+				if Tab.ischild(params[:controller],tab)
+					klass =  'active'
+				end
+			end
+		end
 		klass += " empty" unless tab.subtabs?
 		klass
 	end
 
-	def subtab_class(action = nil)
-		params[:action] == action ? 'active' : ''
+	def subtab_class(action = nil, tab)
+		((action == params[:action] && params[:controller] == tab.id) or action == params[:controller]) ? 'active' : ''
 	end
 
 	def nav_class(tabs)

--- a/app/views/shared/_tabs.html.slim
+++ b/app/views/shared/_tabs.html.slim
@@ -9,9 +9,9 @@
           ul
             - if @advanced
               - tab.advanced_subtabs.each do |subtab|
-                li[class=subtab_class(subtab.id)]
+                li[class=subtab_class(subtab.id,tab)]
                   = link_to t(subtab.label), subtab.url
             - else
               - tab.basic_subtabs.each do |subtab|
-                li[class=subtab_class(subtab.id)]
+                li[class=subtab_class(subtab.id,tab)]
                   = link_to t(subtab.label), subtab.url

--- a/lib/tab.rb
+++ b/lib/tab.rb
@@ -45,6 +45,38 @@ class Tab
 		subtabs
 	end
 
+	def self.find_or_create(controller, label, url)
+		tabs = self.find(controller)
+		if tabs.empty?
+		 tabs << Tab.new(controller, label, url)
+		end
+		tabs.first
+	end
+
+	def self.find(controller)
+		tabs = []
+		AmahiHDA::Application.config.tabs.each do |tab|
+			if tab.id==controller
+				tabs << tab
+				break
+			end
+		end
+		tabs
+	end
+
+	def self.ischild(controller,tab)
+		child = false
+		if tab.subtabs?
+			tab.subtabs.each do |subtab|
+				if(subtab.id == controller)
+					child = true
+					break
+				end
+			end
+		end
+		child
+	end
+
 	private
 
 	# keep top-level tabs in an app variable, due to complex initialzation issues

--- a/plugins/010-users/config/initializers/plugin_init.rb
+++ b/plugins/010-users/config/initializers/plugin_init.rb
@@ -1,4 +1,4 @@
-t = Tab.new("users", "users", "/tab/users")
+t = Tab.find_or_create("users", "users", "/tab/users")
 t.add('index', "details")
 # disable settings for now
 # t.add('settings', "settings")

--- a/plugins/020-shares/config/initializers/plugin_init.rb
+++ b/plugins/020-shares/config/initializers/plugin_init.rb
@@ -1,5 +1,5 @@
 # plugin initialization
-t = Tab.new("shares", "shares", "/tab/shares")
+t = Tab.find_or_create("shares", "shares", "/tab/shares")
 # add any subtabs with what you need. params are controller and the label, for example
 t.add("index", "details")
 #Advanced Tab, workgroup settings

--- a/plugins/030-disks/config/initializers/plugin_init.rb
+++ b/plugins/030-disks/config/initializers/plugin_init.rb
@@ -1,5 +1,5 @@
 # plugin initialization
-t = Tab.new("disks", "disks", "/tab/disks")
+t = Tab.find_or_create("disks", "disks", "/tab/disks")
 # add any subtabs with what you need. params are controller and the label, for example
 t.add("index", "devices")
 t.add("mounts", "partitions")

--- a/plugins/040-apps/config/initializers/plugin_init.rb
+++ b/plugins/040-apps/config/initializers/plugin_init.rb
@@ -1,5 +1,5 @@
 # plugin initialization
-t = Tab.new("apps", "apps", "/tab/apps")
+t = Tab.find_or_create("apps", "apps", "/tab/apps")
 # add any subtabs with what you need. params are controller and the label, for example
 t.add("index", "available")
 t.add("installed", "installed")

--- a/plugins/050-network/config/initializers/plugin_init.rb
+++ b/plugins/050-network/config/initializers/plugin_init.rb
@@ -1,5 +1,5 @@
 # plugin initialization
-t = Tab.new("network", "network", "/tab/network")
+t = Tab.find_or_create("network", "network", "/tab/network")
 # add any subtabs with what you need. params are controller and the label, for example
 t.add("index", "leases")
 t.add("hosts", "hosts")

--- a/plugins/080-settings/config/initializers/plugin_init.rb
+++ b/plugins/080-settings/config/initializers/plugin_init.rb
@@ -1,5 +1,5 @@
 # plugin initialization
-t = Tab.new("settings", "settings", "/tab/settings")
+t = Tab.find_or_create("settings", "settings", "/tab/settings")
 # add any subtabs with what you need. params are controller and the label
 t.add("index", "details")
 t.add("servers", "servers", true)


### PR DESCRIPTION
Now To add a plugin as a sub menu of existing Tab
then 
change in amahi_plugin.yml (mount url will change to /tab/{tab name}/{plugin name})

change in plugin_init.rb:
t = Tab.find_or_create(tabname, tablabel,taburl)
t.add(plugin name. plugin label)
