### PR TITLE
before filter hook to before action hook

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
 
 	protect_from_forgery
 
-	before_action :before_filter_hook
+	before_action :before_action_hook
 	before_action :initialize_validators
 	before_action :prepare_plugins
 


### PR DESCRIPTION
I initially thought that before_filter_hook is a custom method so didn't touched it I tried it in my laptop (ubuntu 16.04) for some reason it worked there but I later tried on my desktop(fedora 24) it failed so changed it before_action_hook. Tested on my laptop also it works 