### PR TITLE
Fixes failing builds

### DIFF
--- a/spec/features/users_tab_spec.rb
+++ b/spec/features/users_tab_spec.rb
@@ -38,7 +38,8 @@ feature "Users tab" do
 	end
 	scenario "should not allow an admin user to revoke its own admin rights", :js => true do
 		find("#whole_user_#{@admin.id}").find("tr").click_link @admin.login
-		expect(page.find_by_id("checkbox_user_admin_#{@admin.id}")[:disabled]).to eq 'disabled'
+		expect(page.find_by_id("checkbox_user_admin_#{@admin.id}")[:checked]).to eq true
+		expect(page.find_by_id("checkbox_user_admin_#{@admin.id}")[:disabled]).to eq true
 	end
 	scenario "should allow an admin user to revoke admin rights to another user", :js => true do
 		user = create(:admin)


### PR DESCRIPTION
page.find_by_id("checkbox_user_admin_1)[:disabled] returns true if disabled="disabled" in html and false or nil otherwise. Tested it using the following code and I think it's worth fixing the breaking builds.  

```ruby
admin_user = create(:admin)
normal_user = create(:user)
visit users_engine.users_path

find("#whole_user_#{admin_user.id}").find("tr").click_link admin_user.login
expect(page.find_by_id("checkbox_user_admin_#{admin_user.id}")[:checked]).to eq true
expect(page.find_by_id("checkbox_user_admin_#{admin_user.id}")[:disabled]).to eq false

find("#whole_user_#{normal_user.id}").find("tr").click_link normal_user.login
expect(page.find_by_id("checkbox_user_admin_#{normal_user.id}")[:checked]).to eq false
```