### PR TITLE
Deprecation Fixes on Rails 4.2.6 and Updating RSpec Syntax to RSpec 3

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -43,12 +43,6 @@ module AmahiHDA
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
 
-    # Enforce whitelist mode for mass assignment.
-    # This will create an empty whitelist of attributes available for mass-assignment for all models
-    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
-    # parameters by using an attr_accessible or attr_protected declaration.
-    # config.active_record.whitelist_attributes = true # deprecated and has no effect
-
     # Enable the asset pipeline
     # config.assets.enabled = true
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,7 @@ module AmahiHDA
     # This will create an empty whitelist of attributes available for mass-assignment for all models
     # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
     # parameters by using an attr_accessible or attr_protected declaration.
-    config.active_record.whitelist_attributes = true
+    # config.active_record.whitelist_attributes = true # deprecated and has no effect
 
     # Enable the asset pipeline
     # config.assets.enabled = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,7 @@ AmahiHDA::Application.configure do
 
   config.eager_load  = false
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
   # Log error messages when you accidentally call methods on nil

--- a/lib/ping.rb
+++ b/lib/ping.rb
@@ -20,10 +20,10 @@ require 'socket'
 class Ping
 	def self.pingecho(host, timeout=5, service="echo")
 		begin
-			timeout(timeout) do
+			Timeout::timeout(timeout) {
 				s = TCPSocket.new(host, service)
 				s.close
-			end
+			}
 		rescue Errno::ECONNREFUSED
 			return true
 		rescue   Timeout::Error, StandardError

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,10 +10,7 @@ FactoryGirl.define do
 		# we do not want to create users in the system
 		before(:create) do |u|
 			allow(u).to receive(:before_create_hook) { nil }
-			# u.stub(:before_create_hook) { nil }
-			# u.stub(:after_save_hook) { nil }
 			allow(u).to receive(:after_save_hook) { nil }
-			# allow(u).to receive(:after_create_hook) { nil }
 		end
 
 		# an admin user

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -9,8 +9,11 @@ FactoryGirl.define do
 
 		# we do not want to create users in the system
 		before(:create) do |u|
-			u.stub(:before_create_hook) { nil }
-			u.stub(:after_save_hook) { nil }
+			allow(u).to receive(:before_create_hook) { nil }
+			# u.stub(:before_create_hook) { nil }
+			# u.stub(:after_save_hook) { nil }
+			allow(u).to receive(:after_save_hook) { nil }
+			# allow(u).to receive(:after_create_hook) { nil }
 		end
 
 		# an admin user

--- a/spec/features/admin_creation_spec.rb
+++ b/spec/features/admin_creation_spec.rb
@@ -10,15 +10,15 @@ feature "Admin creation" do
 	scenario "first login for admin should see the setup page and setup first admin" do
 		(s = Setting.where(:name=>'initialized').first) && s.destroy
 		username = "newuser"
-		User.stub(:system_find_name_by_username) { ["New User", 1000, username] }
+		allow(User).to receive(:system_find_name_by_username) { ["New User", 1000, username] }
 		visit start_path
-		page.should have_content("Amahi initialization")
+		expect(page).to have_content("Amahi initialization")
 		fill_in "username", :with => username
 		fill_in "password", :with => "secret"
 		fill_in "password_confirmation", :with => "secret"
 		click_button "Create"
 		user = User.where(:login => username).first
-		user.admin.should be_truthy
+		expect(user.admin).to be_truthy
 	end
 
 end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -5,25 +5,25 @@ feature "Admin" do
 	scenario "user should see the setup pages after login" do
 		user = create(:admin)
 		visit root_path
-		page.should have_content("Amahi Server Login")
+		expect(page).to have_content("Amahi Server Login")
 		fill_in "username", :with => user.login
 		fill_in "password", :with => "secret"
 		click_button "Log In"
-		page.should have_content("Dashboard")
-		page.should have_content("Setup")
-		page.should have_content("Logout")
+		expect(page).to have_content("Dashboard")
+		expect(page).to have_content("Setup")
+		expect(page).to have_content("Logout")
 	end
 
 	scenario "non-admin users should not see the setup pages after login" do
 		user = create(:user)
 		visit root_path
-		page.should have_content("Amahi Server Login")
+		expect(page).to have_content("Amahi Server Login")
 		fill_in "username", :with => user.login
 		fill_in "password", :with => "secret"
 		click_button "Log In"
-		page.should_not have_content("Setup")
+		expect(page).not_to have_content("Setup")
 		visit users_engine.users_path
-		page.should have_content('You must have admin privileges to access this area')
+		expect(page).to have_content('You must have admin privileges to access this area')
 	end
 
 end

--- a/spec/features/disks_tab_spec.rb
+++ b/spec/features/disks_tab_spec.rb
@@ -11,20 +11,20 @@ feature "Disks tab" do
 	end
 
 	scenario "It should list the created disk" do
-		page.should have_content I18n.translate('model')
-		page.should have_content "Hitachi HDS723020BLA642"
-		page.should have_content I18n.translate('device')
-		page.should have_content '/dev/sda'
-		page.should have_content I18n.translate('temperature')+" (C)"
-		page.should have_content "25"
+		expect(page).to have_content I18n.translate('model')
+		expect(page).to have_content "Hitachi HDS723020BLA642"
+		expect(page).to have_content I18n.translate('device')
+		expect(page).to have_content '/dev/sda'
+		expect(page).to have_content I18n.translate('temperature')+" (C)"
+		expect(page).to have_content "25"
 	end
 
 	scenario "Switching to Fahrenheit then back to Celsius" do
 		click_link "C"
-		page.should have_content I18n.translate('temperature')+" (F)"
-		page.should have_content "77"
+		expect(page).to have_content I18n.translate('temperature')+" (F)"
+		expect(page).to have_content "77"
 		click_link "F"
-		page.should have_content I18n.translate('temperature')+" (C)"
-		page.should have_content "25"
+		expect(page).to have_content I18n.translate('temperature')+" (C)"
+		expect(page).to have_content "25"
 	end
 end

--- a/spec/features/front_page_spec.rb
+++ b/spec/features/front_page_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature "Front page" do
 	scenario "should be the login page by default" do
 		visit root_path
-		page.should have_content("Amahi Server Login")
+		expect(page).to have_content("Amahi Server Login")
 	end
 
 	scenario "should be the dashboard if \"guest dashboard\" is enabled" do
@@ -11,58 +11,58 @@ feature "Front page" do
 		setting.value = "1"
 		setting.save
 		visit root_path
-		page.should have_content("Dashboard")
+		expect(page).to have_content("Dashboard")
 	end
 
 	scenario "should be the login page if \"guest dashboard\" is disabled" do
 		setting = create(:setting, name: "guest-dashboard", value: "0")
 		visit root_path
-		page.should have_content("Amahi Server Login")
+		expect(page).to have_content("Amahi Server Login")
 	end
 
 	scenario "should allow a user with proper username/password to login" do
 		user = create(:user)
 		visit root_path
-		page.should have_content("Amahi Server Login")
+		expect(page).to have_content("Amahi Server Login")
 		fill_in "username", :with => user.login
 		fill_in "password", :with => "secret"
 		click_button "Log In"
-		page.should have_content("Dashboard")
-		page.should have_content("Logout")
+		expect(page).to have_content("Dashboard")
+		expect(page).to have_content("Logout")
 	end
 
 	scenario "should not allow a user with bad username to login" do
 		user = create(:user)
 		visit root_path
-		page.should have_content("Amahi Server Login")
+		expect(page).to have_content("Amahi Server Login")
 		fill_in "username", :with => "bogus"
 		fill_in "password", :with => "secret"
 		click_button "Log In"
-		page.should have_content("Error: Incorrect username or password")
-		page.should have_content("Amahi Server Login")
+		expect(page).to have_content("Error: Incorrect username or password")
+		expect(page).to have_content("Amahi Server Login")
 	end
 
 	scenario "should not allow a user with bad password to login" do
 		user = create(:user)
 		visit root_path
-		page.should have_content("Amahi Server Login")
+		expect(page).to have_content("Amahi Server Login")
 		fill_in "username", :with => user.login
 		fill_in "password", :with => "bogus"
 		click_button "Log In"
-		page.should have_content("Error: Incorrect username or password")
-		page.should have_content("Amahi Server Login")
+		expect(page).to have_content("Error: Incorrect username or password")
+		expect(page).to have_content("Amahi Server Login")
 	end
 
 	scenario "should allow a user with proper username/password to login and also logout" do
 		user = create(:user)
 		visit root_path
-		page.should have_content("Amahi Server Login")
+		expect(page).to have_content("Amahi Server Login")
 		fill_in "username", :with => user.login
 		fill_in "password", :with => "secret"
 		click_button "Log In"
-		page.should have_content("Dashboard")
-		page.should have_content("Logout")
+		expect(page).to have_content("Dashboard")
+		expect(page).to have_content("Logout")
 		click_link "Logout"
-		page.should have_content("Amahi Server Login")
+		expect(page).to have_content("Amahi Server Login")
 	end
 end

--- a/spec/features/network_spec.rb
+++ b/spec/features/network_spec.rb
@@ -18,8 +18,8 @@ feature "Network tab" do
 		fill_in "host[address]" ,:with=> "10"
 		click_button "host_create_button"
 		wait_for_ajax
-		page.should have_content("testIP")
-		page.should have_content("192.168.1.10")
+		expect(page).to have_content("testIP")
+		expect(page).to have_content("192.168.1.10")
 	end
 
 	scenario "Admin should be able to create DNS aliases" do
@@ -29,7 +29,7 @@ feature "Network tab" do
 		fill_in "dns_alias[address]" ,:with=> "10"
 		click_button "dns_alias_create_button"
 		wait_for_ajax
-		page.should have_content("testdns")
-		page.should have_content("192.168.1.10")
+		expect(page).to have_content("testdns")
+		expect(page).to have_content("192.168.1.10")
 	end
 end

--- a/spec/features/shares_tab_spec.rb
+++ b/spec/features/shares_tab_spec.rb
@@ -20,16 +20,16 @@ feature "Shares tab" do
 			click_button "Create"
 			wait_for_ajax
 			visit shares_path
-			page.should have_content I18n.translate('share')
-			page.should have_content I18n.translate('location')
-			page.should have_content "testShare"
-			page.should have_content '\\hda\testShare'
+			expect(page).to have_content I18n.translate('share')
+			expect(page).to have_content I18n.translate('location')
+			expect(page).to have_content "testShare"
+			expect(page).to have_content '\\hda\testShare'
 		end
 
 		scenario "Cannot create a share with no name" do
 			click_button "Create"
 			wait_for_ajax
-			page.should have_content "can't be blank"
+			expect(page).to have_content "can't be blank"
 		end
 
 		scenario "Cannot create share with a duplicate name" do
@@ -39,7 +39,7 @@ feature "Shares tab" do
 			fill_in "Name", :with => share.name
 			click_button "Create"
 			wait_for_ajax
-			page.should have_content "has already been taken"
+			expect(page).to have_content "has already been taken"
 		end
 	end
 
@@ -52,7 +52,7 @@ feature "Shares tab" do
 			click_link "Delete #{@share.name}"
 			wait_for_ajax
 			visit shares_path
-			page.should_not have_content @share.name
+			expect(page).not_to have_content @share.name
 		end
 	end
 

--- a/spec/features/user_create_spec.rb
+++ b/spec/features/user_create_spec.rb
@@ -4,16 +4,16 @@ feature "Users tab" do
   before(:each) do
     user = create(:admin)
     visit root_path
-    page.should have_content("Amahi Server Login")
+    expect(page).to have_content("Amahi Server Login")
     fill_in "username", :with => user.login
     fill_in "password", :with => "secret"
     click_button "Log In"
   end
   scenario "an admin should be able to create a new user", :js => true do
-    page.should have_content("Setup")
+    expect(page).to have_content("Setup")
     visit users_engine.users_path
-    page.should have_content("Username")
-    page.should have_content("Full Name")
+    expect(page).to have_content("Username")
+    expect(page).to have_content("Full Name")
     click_button "New User"
     fill_in "user_login", :with => "newuser"
     fill_in "user_name", :with => "fullname"
@@ -22,8 +22,8 @@ feature "Users tab" do
     click_button "user_create_button"
     wait_for_ajax
     visit users_engine.users_path
-    page.should have_content("newuser")
-    page.should have_content("fullname")
+    expect(page).to have_content("newuser")
+    expect(page).to have_content("fullname")
   end
 
   feature 'user information must be valid to be created' do
@@ -35,7 +35,7 @@ feature "Users tab" do
       fill_in "user_password_confirmation", :with => "secret"
       click_button "user_create_button"
       wait_for_ajax
-      page.should have_content "is too short (minimum is 3 characters)"
+      expect(page).to have_content "is too short (minimum is 3 characters)"
     end
     scenario 'with no full name' do
       visit users_engine.users_path
@@ -45,7 +45,7 @@ feature "Users tab" do
       fill_in "user_password_confirmation", :with => "secret"
       click_button "user_create_button"
       wait_for_ajax
-      page.should have_content "can't be blank"
+      expect(page).to have_content "can't be blank"
     end
     scenario 'with no password' do
       visit users_engine.users_path
@@ -55,7 +55,7 @@ feature "Users tab" do
       fill_in "user_password_confirmation", :with => "secret"
       click_button "user_create_button"
       wait_for_ajax
-      page.should have_content 'is too short (minimum is 4 characters)'
+      expect(page).to have_content 'is too short (minimum is 4 characters)'
     end
     scenario 'with no password confirmation' do
       visit users_engine.users_path
@@ -65,7 +65,7 @@ feature "Users tab" do
       fill_in "user_password", :with => "secret"
       click_button "user_create_button"
       wait_for_ajax
-      page.should have_content "doesn't match Password"
+      expect(page).to have_content "doesn't match Password"
     end
     scenario 'when password doesnt match' do
       visit users_engine.users_path
@@ -77,7 +77,7 @@ feature "Users tab" do
       click_button "user_create_button"
       wait_for_ajax
       page.save_screenshot('image1.jpg')
-      page.should have_content "doesn't match Password"
+      expect(page).to have_content "doesn't match Password"
     end
   end
 end

--- a/spec/features/users_tab_spec.rb
+++ b/spec/features/users_tab_spec.rb
@@ -5,14 +5,14 @@ feature "Users tab" do
     @admin = create(:admin)
     @user = create(:user)
     visit root_path
-    page.should have_content("Amahi Server Login")
+    expect(page).to have_content("Amahi Server Login")
     fill_in "username", :with => @admin.login
     fill_in "password", :with => "secret"
     click_button "Log In"
-    page.should have_content("Setup")
+    expect(page).to have_content("Setup")
     visit users_engine.users_path
-    page.should have_content("Username")
-    page.should have_content("Full Name")
+    expect(page).to have_content("Username")
+    expect(page).to have_content("Full Name")
   end
 	scenario "an admin should be able to create a new user", :js => true do
 		click_button "New User"
@@ -23,14 +23,14 @@ feature "Users tab" do
 		click_button "user_create_button"
 		wait_for_ajax
 		visit users_engine.users_path
-		page.should have_content("newuser")
-		page.should have_content("fullname")
+		expect(page).to have_content("newuser")
+		expect(page).to have_content("fullname")
 	end
 	scenario "should allow an admin user to delete a regular user", :js => true do
 		find("#whole_user_#{@user.id}").find("tr").click_link @user.login
 		expect(page).to have_selector("a#delete-user-#{@user.id}", :visible => true)
 		click_link "delete-user-#{@user.id}"
-		page.should have_no_content(@user.name)
+		expect(page).to have_no_content(@user.name)
 	end
 	scenario "should not allow an admin user to delete its own account" do
 		find("#whole_user_#{@admin.id}").find("tr").click_link @admin.login
@@ -45,20 +45,20 @@ feature "Users tab" do
 		visit users_engine.users_path
 		find("#whole_user_#{user.id}").find("tr").click_link user.login
 		checkbox = "checkbox_user_admin_#{user.id}"
-		page.should have_checked_field(checkbox)
+		expect(page).to have_checked_field(checkbox)
 		page.uncheck(checkbox)
 		wait_for_ajax
-		page.should have_unchecked_field(checkbox)
+		expect(page).to have_unchecked_field(checkbox)
 		expect(user.reload.admin?).to eq false
 	end
 	scenario "should allow an admin user to promote a regular user to admin", :js => true do
 		find("#whole_user_#{@user.id}").find("tr").click_link @user.login
 		checkbox = "checkbox_user_admin_#{@user.id}"
 		expect(@user.admin?).to eq false
-		page.should have_no_checked_field(checkbox)
+		expect(page).to have_no_checked_field(checkbox)
 		page.check(checkbox)
 		wait_for_ajax
-		page.should have_checked_field(checkbox)
+		expect(page).to have_checked_field(checkbox)
 		expect(@user.reload.admin?).to eq true
 	end
 	scenario "should allow an admin user to change his full name", :js => true do
@@ -67,14 +67,14 @@ feature "Users tab" do
 		expect(user_link).to have_selector("a.name_click_change", :visible => true)
 		link = user_link.find("a.name_click_change", :visible => true)
 		link.click
-		page.should have_button('Change')
-		page.should have_field("name",:with=>"#{@admin.name}")
+		expect(page).to have_button('Change')
+		expect(page).to have_field("name",:with=>"#{@admin.name}")
 		within("#form_user_#{@admin.id}") do
 			fill_in "name" ,:with=>"changedname"
 			click_button "Change"
 			wait_for_ajax
 		end
-		user_link.find("table.settings").should have_content("changedname")
+		expect(user_link.find("table.settings")).to have_content("changedname")
 		expect(@admin.reload.name).to eq "changedname"
 	end
 	scenario "should allow an admin user to change the full name of another user", :js => true do
@@ -83,14 +83,14 @@ feature "Users tab" do
 		expect(user_link).to have_selector("a.name_click_change", :visible => true)
 		link = user_link.find("a.name_click_change", :visible => true)
 		link.click
-		page.should have_button('Change')
-		page.should have_field("name",:with=>"#{@user.name}")
+		expect(page).to have_button('Change')
+		expect(page).to have_field("name",:with=>"#{@user.name}")
 		within("#form_user_#{@user.id}") do
 			fill_in "name" ,:with=>"changedname"
 			click_button "Change"
 			wait_for_ajax
 		end
-		user_link.find("table.settings").should have_content("changedname")
+		expect(user_link.find("table.settings")).to have_content("changedname")
 		expect(@user.reload.name).to eq "changedname"
 	end
 	scenario "should allow an admin user to change his password" do
@@ -100,8 +100,8 @@ feature "Users tab" do
 			expect(user_link).to have_selector("a#user-password-control-action-#{@admin.id}", :visible => true)
 			link = user_link.find_by_id("user-password-control-action-#{@admin.id}")
 			link.click
-			user_link.should have_field("user[password]")
-			user_link.should have_field("user[password_confirmation]")
+			expect(user_link).to have_field("user[password]")
+			expect(user_link).to have_field("user[password_confirmation]")
 			password_input = user_link.find_field("user[password]")
 			password_confirm_input = user_link.find_field("user[password_confirmation]")
 			password_input.set "secret"
@@ -119,8 +119,8 @@ feature "Users tab" do
 			expect(user_link).to have_selector("a#user-password-control-action-#{@user.id}", :visible => true)
 			link = user_link.find_by_id("user-password-control-action-#{@user.id}")
 			link.click
-			user_link.should have_field("user[password]")
-			user_link.should have_field("user[password_confirmation]")
+			expect(user_link).to have_field("user[password]")
+			expect(user_link).to have_field("user[password_confirmation]")
 			password_input = user_link.find_field("user[password]")
 			password_confirm_input = user_link.find_field("user[password_confirmation]")
 			password_input.set "secret"

--- a/spec/features/users_tab_spec.rb
+++ b/spec/features/users_tab_spec.rb
@@ -6,8 +6,8 @@ feature "Users tab" do
     @user = create(:user)
     visit root_path
     expect(page).to have_content("Amahi Server Login")
-    fill_in "username", :with => @admin.login
-    fill_in "password", :with => "secret"
+    fill_in "username", :with => "admin"
+    fill_in "password", :with => "admin"
     click_button "Log In"
     expect(page).to have_content("Setup")
     visit users_engine.users_path
@@ -38,7 +38,7 @@ feature "Users tab" do
 	end
 	scenario "should not allow an admin user to revoke its own admin rights", :js => true do
 		find("#whole_user_#{@admin.id}").find("tr").click_link @admin.login
-		expect(page.find_by_id("checkbox_user_admin_#{@admin.id}")[:disabled]).to eq 'disabled'
+		expect(page.find_by_id("checkbox_user_admin_#{@admin.id}")[:disabled]).to eq true
 	end
 	scenario "should allow an admin user to revoke admin rights to another user", :js => true do
 		user = create(:admin)
@@ -133,4 +133,3 @@ feature "Users tab" do
   end
 
 end
-

--- a/spec/features/users_tab_spec.rb
+++ b/spec/features/users_tab_spec.rb
@@ -6,8 +6,8 @@ feature "Users tab" do
     @user = create(:user)
     visit root_path
     expect(page).to have_content("Amahi Server Login")
-    fill_in "username", :with => "admin"
-    fill_in "password", :with => "admin"
+    fill_in "username", :with => @admin.login
+    fill_in "password", :with => "secret"
     click_button "Log In"
     expect(page).to have_content("Setup")
     visit users_engine.users_path

--- a/spec/models/share_spec.rb
+++ b/spec/models/share_spec.rb
@@ -9,7 +9,7 @@ describe Share do
 	end
 
 	it "should have a valid factory" do
-		create(:share).should be_valid
+		expect(create(:share)).to be_valid
 	end
 
 	it "should be invalid without a valid name" do
@@ -33,15 +33,15 @@ describe Share do
 				share_id = Share::DEFAULT_SHARES.index(share_name) + 1
 
 				share = Share.find(share_id)
-				share.name.should             == share_name
-				share.path.should             == "#{Share::DEFAULT_SHARES_ROOT}/#{share_name.downcase}"
-				share.rdonly.should           == false
-				share.visible.should          == true
-				share.everyone.should         == true
-				share.tags.should             == share_name.downcase
-				share.disk_pool_copies.should == 0
-				share.guest_access.should     == false
-				share.guest_writeable.should   == false
+				expect(share.name).to             eq(share_name)
+				expect(share.path).to             eq("#{Share::DEFAULT_SHARES_ROOT}/#{share_name.downcase}")
+				expect(share.rdonly).to           eq(false)
+				expect(share.visible).to          eq(true)
+				expect(share.everyone).to         eq(true)
+				expect(share.tags).to             eq(share_name.downcase)
+				expect(share.disk_pool_copies).to eq(0)
+				expect(share.guest_access).to     eq(false)
+				expect(share.guest_writeable).to   eq(false)
 			end
 		end
 
@@ -51,8 +51,8 @@ describe Share do
 			Share.create_default_shares
 			Share.all.each do |share|
 				User.all.each do |user|
-					share.users_with_share_access.should include(user)
-					share.users_with_write_access.should include(user)
+					expect(share.users_with_share_access).to include(user)
+					expect(share.users_with_write_access).to include(user)
 				end
 			end
 		end
@@ -64,15 +64,15 @@ describe Share do
 		it "should give a user read and write access if the share has everyone: true" do
 			user = create(:user)
 			share = create(:share)
-			share.users_with_share_access.should include(user)
-			share.users_with_write_access.should include(user)
+			expect(share.users_with_share_access).to include(user)
+			expect(share.users_with_write_access).to include(user)
 		end
 
 		it "should NOT give a user readn and write access if the share has everyone: false" do
 			user = create(:user)
 			share = create(:share, everyone: false)
-			share.users_with_share_access.should_not include(user)
-			share.users_with_write_access.should_not include(user)
+			expect(share.users_with_share_access).not_to include(user)
+			expect(share.users_with_write_access).not_to include(user)
 		end
 
 	end

--- a/spec/models/share_spec.rb
+++ b/spec/models/share_spec.rb
@@ -13,15 +13,15 @@ describe Share do
 	end
 
 	it "should be invalid without a valid name" do
-		expect { create(:share, name: nil) }.to raise_error
-		expect { create(:share, name: "") }.to raise_error
-		expect { create(:share, name: "this name is too long because it is over 32 chars") }.to raise_error
-		expect { 2.times{ create(:share, name: "not_unique") } }.to raise_error # name must be unique
+		expect { create(:share, name: nil) }.to raise_error(ActiveRecord::RecordInvalid)
+		expect { create(:share, name: "") }.to raise_error(ActiveRecord::RecordInvalid)
+		expect { create(:share, name: "this name is too long because it is over 32 chars") }.to raise_error(ActiveRecord::RecordInvalid)
+		expect { 2.times{ create(:share, name: "not_unique") } }.to raise_error(ActiveRecord::RecordInvalid) # name must be unique
 	end
 
 	it "should be invalid without a valid path" do
-		expect { create(:share, path: nil) }.to raise_error
-		expect { create(:share, path: "this path is too way long because it has more than sixty four characters") }.to raise_error
+		expect { create(:share, path: nil) }.to raise_error(ActiveRecord::RecordInvalid)
+		expect { create(:share, path: "this path is too way long because it has more than sixty four characters") }.to raise_error(ActiveRecord::RecordInvalid)
 	end
 
 	describe "::create_default_shares" do
@@ -78,4 +78,3 @@ describe Share do
 	end
 
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,3 +71,8 @@ RSpec.configure do |config|
 	end
 
 end
+
+# This is to stub with RSpec in FactoryGirl
+FactoryGirl::SyntaxRunner.class_eval do
+  include RSpec::Mocks::ExampleMethods
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require 'simplecov'
 require 'simplecov_helper'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
-require 'rspec/autorun'
 require 'capybara/rspec'
 require 'capybara/poltergeist'
 require 'factory_girl_rails'

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -11,4 +11,15 @@ end
 
 RSpec.configure do |config|
   config.include WaitForAjax, type: :feature
+
+  # rspec-rails 3 will no longer automatically infer an example group's spec type
+  # from the file location. You can explicitly opt-in to the feature using this
+  # config option.
+  # To explicitly tag specs without using automatic inference, set the `:type`
+  # metadata manually:
+  #
+  #     describe ThingsController, :type => :controller do
+  #       # Equivalent to being in spec/controllers
+  #     end
+  config.infer_spec_type_from_file_location!
 end

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,6 +1,6 @@
 module WaitForAjax
 	def wait_for_ajax
-	  Timeout.timeout(Capybara.default_wait_time) do
+	  Timeout.timeout(Capybara.default_max_wait_time) do
 	    loop do
 	      active = page.evaluate_script('jQuery.active')
 	      break if active == 0


### PR DESCRIPTION
I simply followed the deprecation warnings and edited the code according to them. I also updated the syntax of the specs from RSpec 2 to 3, automatically using this tool:
 [https://github.com/yujinakayama/transpec](url)