### PR TITLE
Fixes app installation progress problem.

### DIFF
--- a/plugins/040-apps/app/controllers/apps_controller.rb
+++ b/plugins/040-apps/app/controllers/apps_controller.rb
@@ -51,7 +51,7 @@ class AppsController < ApplicationController
 			@message = App.installation_message @progress
 		end
 		# we may send HTML if there app is installed or it errored out
-		before_filter_hook if @progress >= 100
+		before_action_hook if @progress >= 100
 	end
 
 	def uninstall

--- a/spec/features/users_tab_spec.rb
+++ b/spec/features/users_tab_spec.rb
@@ -38,7 +38,8 @@ feature "Users tab" do
 	end
 	scenario "should not allow an admin user to revoke its own admin rights", :js => true do
 		find("#whole_user_#{@admin.id}").find("tr").click_link @admin.login
-		expect(page.find_by_id("checkbox_user_admin_#{@admin.id}")[:disabled]).to eq 'disabled'
+		expect(page.find_by_id("checkbox_user_admin_#{@admin.id}")[:checked]).to eq true
+		expect(page.find_by_id("checkbox_user_admin_#{@admin.id}")[:disabled]).to eq true
 	end
 	scenario "should allow an admin user to revoke admin rights to another user", :js => true do
 		user = create(:admin)


### PR DESCRIPTION
Internally installation finishes properly but on the webpage the progress bar just keeps moving even after installation finishes. 
![screenshot from 2017-03-21 11-54-34](https://cloud.githubusercontent.com/assets/6398563/24135032/d9c3436e-0e2d-11e7-9e24-f28d300e8469.png)


It was happening because after installation reached 100% the AppsController#install_progress  used to fail with the following error. 

![screenshot from 2017-03-21 11-52-27](https://cloud.githubusercontent.com/assets/6398563/24135045/f05599a6-0e2d-11e7-878a-95f32fcba472.png)

Changing before_filter_hook to before_action_hook Fixes the problem. 
![screenshot from 2017-03-21 11-55-45](https://cloud.githubusercontent.com/assets/6398563/24135044/f02b8198-0e2d-11e7-867b-c709aec5f3b5.png)
