### PR TITLE
Convert ip address to integer before saving

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -16,6 +16,7 @@
 
 class Host < ApplicationRecord
 
+	before_save :convert_address
 	after_save :restart
 	after_create :restart
 	after_destroy :restart
@@ -32,5 +33,9 @@ class Host < ApplicationRecord
 	def restart
 		# FIXME - only do named
 		system "hda-ctl-hup"
+	end
+
+	def convert_address
+		self.address = self.address.to_i.to_s
 	end
 end


### PR DESCRIPTION
Following cases have been handled:
- '003' will be converted to 3
- 'any string' will be rejected as it is not a number and on conversion to integer it returns 0 which is not allowed
- 'any combination of string and number' will also be rejected