### PR TITLE
Fix #163 Convert news post time to more readable format

### DIFF
--- a/lib/amahi_news.rb
+++ b/lib/amahi_news.rb
@@ -12,9 +12,9 @@
 
 require 'open-uri'
 require 'ping'
+require 'active_support/core_ext/numeric/time'
 
 class AmahiNews
-
 	def self.top(nitems = 5)
 		ret = nil
 		begin
@@ -37,12 +37,32 @@ class AmahiNews
 			result = ActiveSupport::JSON.decode(http.read)
 			result['news'].each_with_index do |item, i|
 				return output if ++i == length
+
+				time_ago = convert_time_to_words(item[2]) rescue item[2]
+
 				output << { :title => item[1], :link => item[0],
-					:date => item[2],
+					:date => time_ago,
 				:comments => item[3] }
+
 			end
 		end
 		output
+	end	
+
+	def self.convert_time_to_words(weeks)
+		weeks_count = weeks.gsub("weeks ago","").to_i 
+		past_time = Time.now - weeks_count.week
+		time_diff = Time.now.to_i - past_time.to_i
+
+		if time_diff > 31556926 # seconds in a year
+			return (time_diff/31556926).to_s+' years ago'
+		elsif time_diff > 2630016 # seconds in a month
+			return (time_diff/2630016).to_s+' months ago'
+		elsif time_diff > 604800 # seconds in a week
+			return (time_diff/604800).to_s+' weeks ago'
+		elsif time_diff > 86400 # seconds in a day
+			return (time_diff/86400).to_s+' days ago'
+		end
 	end
 
 end


### PR DESCRIPTION
Fixed issue #163 

Previously:-
![screenshot from 2018-03-31 11-30-07](https://user-images.githubusercontent.com/13816752/38160252-1495518c-34aa-11e8-8748-210ec482cbe2.png)

Updated:-
![screenshot from 2018-03-31 11-29-27](https://user-images.githubusercontent.com/13816752/38160250-0b33a2d8-34aa-11e8-944d-04a85f44a2cf.png)
