### PR TITLE
added expires in for cache:progress key

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -458,7 +458,7 @@ class App < ApplicationRecord
 	end
 
 	def self.update_progress(progress)
-		Rails.cache.write("progress", progress)
+		Rails.cache.write("progress", progress, expires_in: 59.minutes)
 	end
 
 	# check if app can begin installation or uninstallation

--- a/plugins/040-apps/app/views/apps/_is_installed.html.slim
+++ b/plugins/040-apps/app/views/apps/_is_installed.html.slim
@@ -27,7 +27,7 @@
   = spinner
 
 - if app.theme
-  div.app-url= link_to(t('manage_themes'), settings_engine.themes_path,:class=>"btn btn-info btn-sm", :class => 'f-size22')
+  div.app-url= link_to(t('manage_themes'), settings_engine.themes_path, :class => "btn btn-info btn-sm f-size22")
 
 br
 br


### PR DESCRIPTION
* It's better to expire the cache for "progress" key because if due to some reason cache with "progress" key remains in memory then it will not allow any other app to install. 
* Also fixed redundant class in _is_installed erb file