### PR TITLE
Added .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.gitignore
+/.git
+README.md
+TODO.txt
+COPYING
+/tmp
+/log
+/doc
+/.bundle
+.ruby-version
+.travis.yml
+.dockerignore


### PR DESCRIPTION
.dockerignore file helps in excluding files not relevant to build. This also helps in reducing the size of image and prevents adding unnecessary files to build an image.