### PR TITLE
Replaced old platform image with updated image for Amahi 12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,12 +22,12 @@ services:
       - amahi_mysqldb
 
   amahi_web:
-    image: vikasy/amahi_platform
+    image: sukhbir947/amahi_platform
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     volumes:
       - .:/amahi
     ports:
-      - "3000:3000"
+      - 3000:3000
     depends_on:
       - amahi_mysqldb
     volumes_from:
@@ -39,4 +39,3 @@ services:
     image: busybox
     volumes:
       - /box
-


### PR DESCRIPTION
Before merging this pull request it would better to first merge pull requests #237 and #238 

I have updated the Dockerfile with required configurations for Amahi12 such as using Fedora 29, Rails 5.2.0, etc. and using this updated Dockerfile I have built new "amahi_platform" image with tag "latest" and uploaded it on docker hub.

Amahi 12 docker Image: https://hub.docker.com/r/sukhbir947/amahi_platform

Next, I will also update overview and other details of this docker repository as per standards.

I have tested the new docker image with present platform code and it is working fine!! :smile: 