### PR TITLE
Made app description consistent and single line across themes

### DIFF
--- a/plugins/040-apps/app/helpers/apps_helper.rb
+++ b/plugins/040-apps/app/helpers/apps_helper.rb
@@ -16,10 +16,9 @@
 
 module AppsHelper
 
-  def short_desc(app)
+  def check_desc(app)
     return t('no_description_supplied') unless app.description
-    # truncate if too long
-    truncate(strip_tags(app.description), length: 90)
+    strip_tags(app.description)
   end
 
   def name_with_warning(app)

--- a/plugins/040-apps/app/views/apps/_app_available.html.slim
+++ b/plugins/040-apps/app/views/apps/_app_available.html.slim
@@ -6,8 +6,8 @@
     tr.hover-style
       td.settings-col1.settings-col1-pad1.apps-col1
         = link_to name_with_warning(app), '#'
-      td.settings-col2.apps-col2.p-1[id="app_ip_#{app.identifier}"]
-        = short_desc(app)
+      td.settings-col2.apps-col2.p-1.app-description-single[id="app_ip_#{app.identifier}"]
+        = check_desc(app)
 
   .settings-stretcher[id="app_info_#{app.identifier}" style="#{display_style}"]
     .app-manage.collapsed-div-style.f-size13.text-secondary

--- a/plugins/040-apps/app/views/apps/_app_installed.html.slim
+++ b/plugins/040-apps/app/views/apps/_app_installed.html.slim
@@ -6,8 +6,8 @@
     tr.hover-style
       td.settings-col1.settings-col1-pad1.apps-col1
         = link_to name_with_warning(app), '#'
-      td.settings-col2.apps-col2.p-1[id="app_ip_#{app.identifier}"]
-        = short_desc(app)
+      td.settings-col2.apps-col2.p-1.app-description-single[id="app_ip_#{app.identifier}"]
+        = check_desc(app)
 
   .settings-stretcher[id="app_info_#{app.identifier}" style="#{display_style}"]
     .app-manage.collapsed-div-style.f-size13.text-secondary

--- a/public/themes/beach/stylesheets/style.css
+++ b/public/themes/beach/stylesheets/style.css
@@ -430,3 +430,35 @@ footer a[href="/logout"]:hover, footer a[href="/login"]:hover{
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/*App description stylings*/
+
+@media screen and (min-width: 992px) {
+  .app-description-single{
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    display: inline-block;
+    width: 486px !important;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 991px) {
+  .app-description-single{
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    display: inline-block;
+    width: 325px !important;
+  }
+}
+
+@media (min-width: 576px) and (max-width: 768px) {
+  .app-description-single{
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    display: inline-block;
+    width: 220px !important;
+  }
+}

--- a/public/themes/default/stylesheets/style.css
+++ b/public/themes/default/stylesheets/style.css
@@ -684,6 +684,15 @@ section#dashboard {
     width: 700px;
     margin-left: 0px;
   }
+
+  .app-description-single{
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    display: inline-block;
+    width: 610px !important;
+  }
+
 }
 
 @media (min-width: 768px) and (max-width: 991px) {
@@ -691,6 +700,15 @@ section#dashboard {
     width: 450px;
     margin-left: 0px;
   }
+
+  .app-description-single{
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    display: inline-block;
+    width: 430px !important;
+  }
+
 }
 
 @media (min-width: 576px) and (max-width: 768px) {
@@ -698,6 +716,15 @@ section#dashboard {
     width: 540px;
     margin-left: 60px;
   }
+
+  .app-description-single{
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    display: inline-block;
+    width: 312px !important;
+  }
+
 }
 
 .tab-link-style, .active-tab-link-style{

--- a/public/themes/vertical/stylesheets/style.css
+++ b/public/themes/vertical/stylesheets/style.css
@@ -179,3 +179,35 @@ nav.preftab {
 .tab-link-style{
   border-bottom: 0px !important;
 }
+
+/*App description stylings*/
+
+@media screen and (min-width: 992px) {
+  .app-description-single{
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    display: inline-block;
+    width: 486px !important;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 991px) {
+  .app-description-single{
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    display: inline-block;
+    width: 325px !important;
+  }
+}
+
+@media (min-width: 576px) and (max-width: 768px) {
+  .app-description-single{
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    display: inline-block;
+    width: 220px !important;
+  }
+}


### PR DESCRIPTION
It's way better to convert app description to a single line from front-end instead of concatenating it from backend and using CSS styling to make it consistent across all themes. 