### PR TITLE
Added component to Apps Tab for showing app installation status on reload

### DIFF
--- a/plugins/040-apps/app/views/apps/index.html.slim
+++ b/plugins/040-apps/app/views/apps/index.html.slim
@@ -2,6 +2,24 @@
   .col-xs-6.col-sm-6.col-md-6.col-lg-6.get-apps = link_to 'Get apps', 'https://www.amahi.org/apps', :title => 'Amahi App Store', :target => '_blank', :id => 'btn-get-apps'
   .col-xs-6.col-sm-6.col-md-6.col-lg-6.install-apps = link_to 'Install here!', apps_engine.root_path, :title => 'Refresh', :id => 'btn-install-apps'
 
+- progress = Rails.cache.read("progress")
+- type = Rails.cache.read("type")
+- unless (progress.blank? || (progress == 0 && type == "uninstall") || (progress == 100 && type == "install") || (progress<0) || (progress>100))
+  - app_id = Rails.cache.read("app-id")
+  - app = AmahiApi::App.find(app_id)
+  - status = type == "install" ? t('installing_application') : t('uninstalling_application')  
+  - progress = (100-progress) if type == "uninstall"
+
+  .container.app-installing
+    span.installation-status class="app_name_#{app_id}"
+      = status + ": " + app.name
+
+    // = button_tag t('clear'), :type => 'button', :class => 'btnn btn-create btn btn-info float-right mb-1', :id => "clear-app-installation",  :data => { :related => "#new-user-step1" }
+
+    .progress.progress-bar-div.mt-2 style="width: 100%; display: inline-block; background: #c7c7c7;"
+      .progress-bar.progress-bar-striped.progress-bar-animated.bg-info.global-progress aria-valuemax="100" \aria-valuemin="0" aria-valuenow="0" role="progressbar" style="width: #{progress}%; height: 100%;"
+        = "#{progress}%"
+
 #apps-table
   .settings-table
     - if @apps.any?

--- a/plugins/040-apps/app/views/apps/installed.html.slim
+++ b/plugins/040-apps/app/views/apps/installed.html.slim
@@ -1,6 +1,25 @@
 .app-store-header.row
   .col-xs-6.col-sm-6.col-md-6.col-lg-6.get-apps = link_to 'Get apps', 'https://www.amahi.org/apps', :title => 'Amahi App Store', :target => '_blank', :id => 'btn-get-apps'
   .col-xs-6.col-sm-6.col-md-6.col-lg-6.install-apps = link_to 'Install here!', apps_engine.root_path, :title => 'Refresh', :id => 'btn-install-apps'
+
+- progress = Rails.cache.read("progress")
+- type = Rails.cache.read("type")
+- unless (progress.blank? || (progress == 0 && type == "uninstall") || (progress == 100 && type == "install") || (progress<0) || (progress>100))
+  - app_id = Rails.cache.read("app-id")
+  - app = AmahiApi::App.find(app_id)
+  - status = type == "install" ? t('installing_application') : t('uninstalling_application')
+  - progress = (100-progress) if type == "uninstall"
+
+  .container.app-installing
+    span.installation-status class="app_name_#{app_id}"
+      = status + ": " + app.name
+
+    // = button_tag t('clear'), :type => 'button', :class => 'btnn btn-create btn btn-info float-right mb-1', :id => "clear-app-installation",  :data => { :related => "#new-user-step1" }
+
+    .progress.progress-bar-div.mt-2 style="width: 100%; display: inline-block; background: #c7c7c7;"
+      .progress-bar.progress-bar-striped.progress-bar-animated.bg-info.global-progress aria-valuemax="100" \aria-valuemin="0" aria-valuenow="0" role="progressbar" style="width: #{progress}%; height: 100%;"
+        = "#{progress}%"
+
 #apps-table
   .settings-table
     - if @apps.any?

--- a/plugins/040-apps/config/locales/en.yml
+++ b/plugins/040-apps/config/locales/en.yml
@@ -3,3 +3,6 @@
 'en':
   # put here your string symbols and translations
   hello_world: Hello World! (yay for the Amahi plugins!)
+  installing_application: Installing Application
+  uninstalling_application: Uninstalling Application
+  clear: Clear

--- a/public/themes/default/stylesheets/style.css
+++ b/public/themes/default/stylesheets/style.css
@@ -1758,3 +1758,17 @@ span#setting_dns select{
 .pd-l-12{
   padding-left: 12px !important;
 }
+
+.app-installing{
+  background: white;
+  margin-top: 15px;
+  margin-bottom: 15px;
+  border-radius: 4px;
+  padding: 15px;
+  font-size: 15px;
+}
+
+.installation-status{
+  padding-top: 4px;
+  display: inline-block;
+}


### PR DESCRIPTION
The problem is when the installation of an Amahi app starts and someone refreshes the page, the app continues to install in the backend. but the user only sees the progress when it again clicks on the install button of that app. To solve this problem I have implementing this, when someone refreshes the page, before loading frontend the backend checks if an application is getting install/uninstall then it shows a new div at top of apps tab and shows its current progress with application name and status.