### PR TITLE
Name Field in Users Plugin take correct input format

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -11,7 +11,7 @@ development:
   pool: 5
   database: hda_development
   username: root
-  password: hda
+  password: very_strong_password
   host: localhost
   socket: <%= [
      '/var/lib/mysql/mysql.sock', # Fedora.

--- a/plugins/010-users/app/controllers/users_controller.rb
+++ b/plugins/010-users/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
 	def create
 		sleep 2 if development?
 		@user = User.new(params_user_create)
-		@user.save
+		@user.save 
 		@users = User.all_users	unless @user.errors.any?
 	end
 
@@ -38,7 +38,7 @@ class UsersController < ApplicationController
 		user = User.find params[:id]
 		name = user.name
 		if can_i_edit_details?(user)
-			if(params[:name].strip.length !=0)
+			if(params[:name].strip.length !=0 && (/[^a-zA-Z]+/ =~ params[:name]) == nil)
 				user.name = params[:name]
 				user.save!
 				name = user.name
@@ -107,7 +107,7 @@ class UsersController < ApplicationController
 
 	def update_name
 		@user = User.find(params[:id])
-		@user.update_attributes(params_name_update)
+		@user.update_attributes(params_name_update) 
 		render :json => { :status => @user.errors.any? ? :not_acceptable : :ok }
 	end
 

--- a/plugins/010-users/app/views/users/_form.html.slim
+++ b/plugins/010-users/app/views/users/_form.html.slim
@@ -19,7 +19,7 @@
           .controls= f.text_field :login, :size => 16, :maxlength => 20, :class=>'form-control',:placeholder => t('username')
 
         .control-group.form-group
-          .controls= f.text_field :name, :size => 16, :maxlength => 64, :class=>'form-control', :placeholder => t('full_name')
+          .controls= f.text_field :name, :size => 16, :maxlength => 64, :class=>'form-control',:pattern => "[a-zA-Z]+", :placeholder => t('full_name')
 
         .control-group.form-group
           .controls= f.password_field :password, :size => 16, :maxlength => 24, :class=>'form-control',:placeholder => t('password')


### PR DESCRIPTION
Issue #245 
The Name Field of Users Plugin is not going to accept the input format that is going to contain the numbers or special characters.
![Screenshot from 2019-11-03 14-13-52](https://user-images.githubusercontent.com/36095454/68082554-4e83c300-fe44-11e9-86f3-b5c156c0f1a8.png)
![Screenshot from 2019-11-03 14-13-54](https://user-images.githubusercontent.com/36095454/68082557-53e10d80-fe44-11e9-88a7-adfa493f86a1.png)
![Screenshot from 2019-11-03 14-14-29](https://user-images.githubusercontent.com/36095454/68082558-5b081b80-fe44-11e9-8fc1-3bec73e1cd0a.png)


